### PR TITLE
Add retry()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Then somewhere in your node.js application:
 * [`series`](#series)
 * [`timeout`](#timeout)
 * [`whilst`](#whilst), `doWhilst`
+* [`retry`](#retry)
 
 
 # Utilities
@@ -160,4 +161,38 @@ Example:
     )
     .then(function(result) {
        // result will be 10 here.
+    });
+
+<a name="retry"/>
+### retry(options, fn)
+
+Will continuously call `fn` until it returns a synchronous value, doesn't throw, or returns a Promise that resolves. It will be retried `options.times`. You can pass `{times: Infinity}` to retry indefinitely. The `fn` will be passed the `lastAttempt` object which is the Error object of the last attempt.
+
+Options: `times` (Default=5) and `interval` (Default=0). `interval` is the time between retries in milliseconds. If the `options` argument is passed as just a number, only `times` will be set.
+
+Examples:
+
+    var count = 0;
+    promiseTools.retry({times: 4, interval: 5}, function(lastAttempt) {
+        count++;
+        if (count === 2) Promise.resolve(true);
+        else Promise.reject(new Error('boom'));
+    })
+    .then(function(result) {
+       // result will be `true` here.
+    });
+
+    ---------------------------------------------
+
+    var count = 0;
+    promiseTools.retry(1, function(lastAttempt) {
+        count++;
+        if (count === 2) Promise.resolve(true);
+        else Promise.reject(new Error('boom'));
+    })
+    .then(function(result) {
+       // will not resolve.
+    })
+    .catch(function(err) {
+        // err.message should be `boom` here.
     });

--- a/test/retry.js
+++ b/test/retry.js
@@ -20,15 +20,15 @@ describe('retry', () => {
     });
 
     it('should retry infinitely and resolve', () => {
-        let retry = promiseTools.retry(-1, getTest(3));
+        let retry = promiseTools.retry(Infinity, getTest(3));
         return expect(retry).to.eventually.equal(3);
     });
 
     it('should reject', (done) => {
         let retry = promiseTools.retry(3, getTest(4));
-        retry.catch((attempts) => {
+        retry.catch((lastAttempt) => {
             try {
-                expect(attempts.length).to.eq(3);
+                expect(lastAttempt).to.be.instanceof(Error);
                 done();
             } catch (err) {
                 done(err);
@@ -58,12 +58,4 @@ describe('retry', () => {
         });
         expect(p).to.eventually.be.rejectedWith('Unsupported argument type for \'times\': undefined');
     });
-
-    it('should reject when an Error value is resolved', () => {
-        let retry = promiseTools.retry(1, () => {
-            return new Error('boom');
-        });
-        return expect(retry).to.eventually.be.rejectedWith('boom');
-    });
-
 });

--- a/test/retry.js
+++ b/test/retry.js
@@ -1,0 +1,69 @@
+"use strict"
+
+let chai = require('chai');
+chai.use(require('chai-as-promised'));
+let expect = chai.expect;
+let promiseTools = require('../src');
+
+let callCount = 0;
+let getTest = (times) => {
+    return () => {
+        callCount++;
+        if (callCount === times) return callCount;
+        else throw new Error('not done yet');
+    }
+}
+
+describe('retry', () => {
+    beforeEach(() => {
+        callCount = 0;
+    });
+
+    it('should retry infinitely and resolve', () => {
+        let retry = promiseTools.retry(-1, getTest(3));
+        return expect(retry).to.eventually.equal(3);
+    });
+
+    it('should reject', (done) => {
+        let retry = promiseTools.retry(3, getTest(4));
+        retry.catch((attempts) => {
+            try {
+                expect(attempts.length).to.eq(3);
+                done();
+            } catch (err) {
+                done(err);
+            }
+        })
+    });
+
+    [
+        {options: {times: 5, interval: 10}, msg: 'times and interval'},
+        {options: {times: 5}, msg: 'just times'},
+        {options: {}, msg: 'neither times nor interval'}
+    ].forEach((args) => {
+        it(`should accept first argument as an options hash with ${args.msg}`, () => {
+            let retry = promiseTools.retry(args.options, getTest(5));
+            return expect(retry).to.eventually.equal(5);
+        });
+    });
+
+    it('should return an error with invalid options argument', () => {
+        let p = Promise.resolve().then(() => {
+            // had to do this for some reason. Otherwise `chai-as-promised` always passed erroneously.
+            try {
+                return promiseTools.retry(undefined, getTest(1));
+            } catch (err) {
+                throw err;
+            }
+        });
+        expect(p).to.eventually.be.rejectedWith('Unsupported argument type for \'times\': undefined');
+    });
+
+    it('should reject when an Error value is resolved', () => {
+        let retry = promiseTools.retry(1, () => {
+            return new Error('boom');
+        });
+        return expect(retry).to.eventually.be.rejectedWith('boom');
+    });
+
+});


### PR DESCRIPTION
Followed async's [retry](https://github.com/caolan/async#retry) api. Added ability to retry forever. Also allows the `fn` parameter to be synchronous or Promise based. async's version could only be callback based.

Wrote tests to fully cover what I added. `chai-as-promised` was being weird sometimes, and would pass, however, if I changed the result of the expected it would _still_ pass. So I added some try/catches in places. 

The main idea for adding `FOREVER` came from why I starting thinking about implementing this. I was writing a test, and wanted to only resolve a variable was `true`, i.e. a _check_ passed. So, ideally, you want to be able to wait forever. Originally I was going to do `promiseTools.waitUntil`, but `retry` seemed to already fit the description. 
