### PR TITLE
Fix retry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ exports.retry = (options, fn) => {
         if ('number' === typeof(options.times)) times = +options.times;
         else if (options.times) return Promise.reject(makeTimeOptionError(options.times));
 
-        if (options.interval) interval = parseInt(options.interval, 10);
+        if (options.interval) interval = +options.interval;
     }
     else if (options) return Promise.reject(makeTimeOptionError(options));
     else return Promise.reject(new Error('No parameters given'));

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ exports.doWhilst = (fn, test) => {
 
 /*
  * keep calling `fn` until it returns a non-error value, doesn't throw, or returns a Promise that resolves. `fn` will be
- * attempted `times` many times before rejecting. If `times` is given as `exports.FOREVER`, then `retry` will attempt to
+ * attempted `times` many times before rejecting. If `times` is given as `Infinity`, then `retry` will attempt to
  * resolve forever (useful if you are just waiting for something to finish).
  * @param {Object|Number} options hash to provide `times` and `interval`. Defaults (times=5, interval=0). If this value
  *                        is a number, only `times` will be set.
@@ -222,16 +222,20 @@ exports.retry = (options, fn) => {
     let attempts = 0;
     let lastAttempt = null;
 
-    if ('number' === typeof(options)) {
-        times = options;
+    function makeTimeOptionError(value) {
+        return new Error(`Unsupported argument type for \'times\': ${typeof(value)}`);
     }
+
+    if ('function' === typeof(options)) fn = options;
+    else if ('number' === typeof(options)) times = +options;
     else if ('object' === typeof(options)) {
-        if (options.times) {times = parseInt(options.times, 10);}
-        if (options.interval) {interval = parseInt(options.interval, 10);}
+        if ('number' === typeof(options.times)) times = +options.times;
+        else if (options.times) return Promise.reject(makeTimeOptionError(options.times));
+
+        if (options.interval) interval = parseInt(options.interval, 10);
     }
-    else {
-        throw new Error('Unsupported argument type for \'times\': ' + typeof(options));
-    }
+    else if (options) return Promise.reject(makeTimeOptionError(options));
+    else return Promise.reject(new Error('No parameters given'));
 
     return new Promise((resolve, reject) => {
         let doIt = () => {

--- a/test/retry.js
+++ b/test/retry.js
@@ -39,6 +39,8 @@ describe('retry', () => {
     [
         {options: {times: 5, interval: 10}, msg: 'times and interval'},
         {options: {times: 5}, msg: 'just times'},
+        {options: {times: 5.4}, msg: 'just times'},
+        {options: {times: Infinity}, msg: 'times = Infinity'},
         {options: {}, msg: 'neither times nor interval'}
     ].forEach((args) => {
         it(`should accept first argument as an options hash with ${args.msg}`, () => {
@@ -47,15 +49,21 @@ describe('retry', () => {
         });
     });
 
+    it('should call the default 5 times with no options provided', () => {
+        let retry = promiseTools.retry(getTest(5));
+        return expect(retry).to.eventually.equal(5);
+    })
+
+    it('should throw when given a bogus `times` option', () => {
+        let retry = promiseTools.retry('5', getTest(5));
+        return expect(retry).to.be.eventually.rejected;
+    })
+
     it('should return an error with invalid options argument', () => {
-        let p = Promise.resolve().then(() => {
-            // had to do this for some reason. Otherwise `chai-as-promised` always passed erroneously.
-            try {
-                return promiseTools.retry(undefined, getTest(1));
-            } catch (err) {
-                throw err;
-            }
-        });
-        expect(p).to.eventually.be.rejectedWith('Unsupported argument type for \'times\': undefined');
+        expect(promiseTools.retry(undefined, getTest(1))).to.eventually.be.rejectedWith('Unsupported argument type for \'times\': undefined');
     });
+
+    it('should reject when called with nothing', () => {
+        expect(promiseTools.retry()).to.eventually.be.rejectedWith('No parameters given');
+    })
 });

--- a/test/retry.js
+++ b/test/retry.js
@@ -41,7 +41,8 @@ describe('retry', () => {
         {options: {times: 5}, msg: 'just times'},
         {options: {times: 5.4}, msg: 'just times'},
         {options: {times: Infinity}, msg: 'times = Infinity'},
-        {options: {}, msg: 'neither times nor interval'}
+        {options: {}, msg: 'neither times nor interval'},
+        {options: {interval: Infinity}, msg: 'Should accept Infinity interval'}
     ].forEach((args) => {
         it(`should accept first argument as an options hash with ${args.msg}`, () => {
             let retry = promiseTools.retry(args.options, getTest(5));


### PR DESCRIPTION
Made it so `options.times` accepts `Infinity` as a value, as it should have. As well, `options.interval` can also accept anything, as non number values for `setTimeout` will be treated as 0. 

Updated tests. 

I have made it so invalid (non-number) values for the first argument and `options.times` return rejected Promises. The other option is to just use the default values. Although, I find it confusing when libraries use default values in error, because you may expect your program to fail/pass, but it works because the library let it through. Your call. 
