### PR TITLE
Add Typescript 2.1.x definitions and small test to ensure validity.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,91 @@
+// Type definitions for promise-tools
+// Project: node-promise-tools
+// Definitions by: Calvin Wiebe calvin.wiebe@gmail.com
+
+declare class TimeoutError extends Error {}
+type PromiseGeneratingFunction<t> = () => Promise<t>;
+
+/**
+ * Returns a Promise which resolves after `ms` milliseconds have elapsed.  The returned Promise will never reject.
+ */
+export function delay(ms: number): Promise<void>;
+
+type Deferred<t> = {
+    promise: Promise<t>;
+    resolve: (result: t) => t;
+    reject: (error: any) => any;
+};
+/**
+ * Returns a `{promise, resolve, reject}` object.  The returned `promise` will resolve or reject when `resolve` or
+ * `reject` are called.
+ */
+export function defer<t>(): Deferred<t>;
+
+/**
+ * Given an array, `tasks`, of functions which return Promises, executes each function in `tasks` in series, only
+ * calling the next function once the previous function has completed.
+ */
+export function series<t>(tasks: PromiseGeneratingFunction<t>[]): Promise<t[]>;
+
+/**
+ * Given an array, `tasks`, of functions which return Promises, executes each function in `tasks` in parallel.
+ * If `limit` is supplied, then at most `limit` tasks will be executed concurrently.
+ */
+export function parallel<t>(tasks: PromiseGeneratingFunction<t>[], limit?: number): Promise<t[]>;
+
+
+type MapIterator<t> = (item: t, index: number) => Promise<t>;
+/**
+ * Given an array `arr` of items, calls `iter(item, index)` for every item in `arr`.  `iter()` should return a
+ * Promise.  Up to `limit` items will be called in parallel (defaults to 1.)
+ */
+export function map<t>(arr: t[], iter: MapIterator<t>, limit?: number): Promise<t[]>;
+
+/**
+ * Add a timeout to an existing Promise.
+ *
+ * Resolves to the same value as `p` if `p` resolves within `ms` milliseconds, otherwise the returned Promise will
+ * reject with the error "Timeout: Promise did not resolve within ${ms} milliseconds"
+ */
+export function timeout<t>(p: Promise<t>, ms: number): Promise<t>;
+
+/**
+ * Continually call `fn()` while `test()` returns true.
+ *
+ * `fn()` should return a Promise.  `test()` is a synchronous function which returns true of false.
+ *
+ * `whilst` will resolve to the last value that `fn()` resolved to, or will reject immediately with an error if
+ * `fn()` rejects or if `fn()` or `test()` throw.
+ */
+export function whilst<t>(test: () => boolean, fn: PromiseGeneratingFunction<t>): Promise<t>;
+
+/**
+ * Same as `whilst` but will call `test()` before trying `fn`
+ */
+export function doWhilst<t>(fn: PromiseGeneratingFunction<t>, test: () => boolean): Promise<t>;
+
+/**
+ * Function to be called until resolves by `retry`. It will be passed the `lastAttempt` failure of the previous call.
+ */
+type RetryTask<t> = (lastAttempt: any) => Promise<t>;
+
+/**
+ * Options for the retry method
+ */
+type RetryOptions = number | {
+    times: number,
+    interval: number
+}
+
+/**
+ * Will call `fn` 5 times until it resolves. If after 5 tries `fn` still rejects, `retry` will reject
+ * with the last error
+ */
+export function retry<t>(fn: RetryTask<t>): Promise<t>;
+
+/**
+ * Continually call `fn` until it resolves. `retry` will call it `options.times` before giving up and rejecting. The
+ * default amount of times is 5. You can set it to `Infinity` to try forever. The interval between each retry is 0,
+ * unless specified in milliseconds in `options.interval`.
+ */
+export function retry<t>(options: Partial<RetryOptions>, fn: RetryTask<t>): Promise<t>;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Tools for working with Promises",
   "main": "lib/index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "quicktest": "mocha",
     "test": "mocha --compilers js:babel-core/register",
@@ -23,6 +24,7 @@
   "author": "Jason Walton <dev@lucid.thedreaming.org> (https://github.com/jwalton)",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "6.0.52",
     "babel-cli": "^6.1.18",
     "babel-core": "^6.1.21",
     "babel-preset-es2015": "^6.1.18",
@@ -31,6 +33,7 @@
     "coveralls": "^2.11.4",
     "es6-promise": "^3.0.2",
     "isparta": "^4.0.0",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "typescript": "2.1.4"
   }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "sourceMap": true,
+    "noImplicitAny": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,0 +1,66 @@
+import * as pt from '../';
+
+let promises: Promise<any>[] = [];
+
+promises.push(pt.retry<Number>((): Promise<Number> => {
+    return Promise.resolve(1);
+}));
+
+promises.push(pt.retry<String>({times: Infinity, interval: 5000}, (): Promise<String> => {
+    return Promise.resolve('what');
+}));
+
+promises.push(pt.retry<String>(2, (): Promise<String> => {
+    return Promise.resolve('what');
+}));
+
+promises.push(pt.delay(1000).then(() => console.log('done delay')));
+
+const deferred = pt.defer<string>();
+
+promises.push(deferred.promise.then((something) => { something.charAt(0); }));
+
+deferred.resolve('what');
+
+const pSeries = pt.series<any>([
+    () => (Promise.resolve('1')),
+    () => (Promise.resolve(2))
+]);
+
+promises.push(pSeries);
+
+const pParallel = pt.parallel<string>([
+    () => (Promise.resolve('1')),
+    () => (Promise.resolve('3'))
+], 0);
+
+promises.push(pParallel);
+
+const pMap = pt.map([1, 2, 3, 3], (item, index) => (Promise.resolve(item * item)), 0);
+
+promises.push(pMap);
+
+promises.push(pt.timeout(pt.delay(1000).then(() => 999), 2000));
+
+let tries = 0;
+const pWhilst = pt.whilst(() => (tries < 3), () => {
+    tries++;
+    return Promise.resolve(tries * 2);
+});
+promises.push(pWhilst);
+
+let tries2 = 0;
+const pDoWhilst = pt.doWhilst<number>(() => {
+    tries2++;
+    return Promise.resolve(tries2 * 2);
+}, () => (tries2 < 3));
+promises.push(pDoWhilst);
+
+Promise.all(promises)
+.then(result => {
+    console.log(result);
+});
+
+const error = new pt.TimeoutError();
+
+console.log(error instanceof Error);

--- a/test/typescriptSpec.js
+++ b/test/typescriptSpec.js
@@ -1,14 +1,14 @@
 'use strict';
 
 let {exec} = require('child_process');
-let path = require('path');
 let {expect} = require('chai');
 
+// This just makes sure the `typescript.ts` file compiles
 describe('Typescript', () => {
     describe('build', () => {
-        it('must build without error', function (done) {
+        it('must build without error', (done) => {
             this.timeout(10000);
-            exec('tsc --noEmit', {cwd: 'test', }, function (error) {
+            exec('tsc --noEmit', {cwd: 'test'}, (error) => {
                 expect(error).to.eq(null);
                 done();
             });

--- a/test/typescriptSpec.js
+++ b/test/typescriptSpec.js
@@ -6,7 +6,7 @@ let {expect} = require('chai');
 // This just makes sure the `typescript.ts` file compiles
 describe('Typescript', () => {
     describe('build', () => {
-        it('must build without error', (done) => {
+        it('must build without error', function(done) {
             this.timeout(10000);
             exec('tsc --noEmit', {cwd: 'test'}, (error) => {
                 expect(error).to.eq(null);

--- a/test/typescriptSpec.js
+++ b/test/typescriptSpec.js
@@ -1,0 +1,17 @@
+'use strict';
+
+let {exec} = require('child_process');
+let path = require('path');
+let {expect} = require('chai');
+
+describe('Typescript', () => {
+    describe('build', () => {
+        it('must build without error', function (done) {
+            this.timeout(10000);
+            exec('tsc --noEmit', {cwd: 'test', }, function (error) {
+                expect(error).to.eq(null);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hey @jwalton!

As you may have guessed, I'm now using typescript. More transpiling! It is actually pretty neat. And, I pulled in `promise-tools` into our project, and thought it would be nice to have definitions for it. It lets the Sublime plugin I'm using, and VSCode my coworkers are using, autocomplete `promise-tools` and make them use the library correctly (pass the proper options and use proper return values), or else the `tsc` compiler yells at us. 

I'm not sure how inclined you are to add this, or how familiar you are with Typescript. For completeness, there are [two](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) conventions for publishing types. The first is to bundle it with your module, which is this pr. Or, I could publish them separately to the `@types` scope on `npm` if you don't want the fluff. Bundling it with your module is the preferred way, because anyone grabbing your module just gets the definitions without any extra steps, and the definitions are inline with each release. I suppose this does mean you'd need to update the types with each revision... You can ping me to do that. :P. Let me know what you think. I hope all is well. 
